### PR TITLE
add backend auth0 integration

### DIFF
--- a/Backend/CoolinaryAPI/Auth/AuthenticationExtension.cs
+++ b/Backend/CoolinaryAPI/Auth/AuthenticationExtension.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace CoolinaryAPI.Auth;
+
+public static class AuthenticationExtension
+{
+    internal static void AddAuth0(this IServiceCollection services, WebApplicationBuilder builder) 
+    {
+        var authBuilder = new AuthenticationBuilder(services);
+
+        authBuilder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.Authority = $"https://{builder.Configuration["Auth0:Domain"]}";
+                options.Audience = builder.Configuration["Auth0:Audience"];
+                options.TokenValidationParameters = new TokenValidationParameters() 
+                {
+                    
+                    ValidAudience = builder.Configuration["Auth0:Audience"],
+                    ValidIssuer = $"{builder.Configuration["Auth0:Domain"]}",
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true
+                };
+            });
+    }
+}

--- a/Backend/CoolinaryAPI/CoolinaryAPI.sln
+++ b/Backend/CoolinaryAPI/CoolinaryAPI.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.8.34408.163
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoolinaryAPI", "CoolinaryAPI.csproj", "{69C8F930-1618-4CD0-9A0F-07AC246F666C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "..\Domain\Domain.csproj", "{29F20AAC-4FD8-4259-9EB5-77EFBE2A7206}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{69C8F930-1618-4CD0-9A0F-07AC246F666C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69C8F930-1618-4CD0-9A0F-07AC246F666C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69C8F930-1618-4CD0-9A0F-07AC246F666C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29F20AAC-4FD8-4259-9EB5-77EFBE2A7206}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29F20AAC-4FD8-4259-9EB5-77EFBE2A7206}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29F20AAC-4FD8-4259-9EB5-77EFBE2A7206}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29F20AAC-4FD8-4259-9EB5-77EFBE2A7206}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Backend/CoolinaryAPI/appsettings.json
+++ b/Backend/CoolinaryAPI/appsettings.json
@@ -7,9 +7,8 @@
   },
   "AllowedHosts": "*",
 
-  "JWT": {
-      "Key": "YourSecretKeyHereThatIsExactly64BytesLongAndAdequatelySecure"
+  "Auth0": {
+    "Domain": "dreamers.eu.auth0.com",
+    "Audience": "https://coolinary.com/api"
   }
-
-
 }

--- a/Backend/Domain/Domain.csproj
+++ b/Backend/Domain/Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
# Summary
Adds Auth0 integration for the authentication. Which is needed to call our API's endpoints.

## Changes
* Added Authentication Extension to refactor some code.
* Added Domain project because we will needed anyways.
* Adapted Swagger for Bearer schema.

## Notes
Still needed to check what endpoint and what data we have to send to get an access token from Auth0.